### PR TITLE
Keyboard handling improvements

### DIFF
--- a/src/components/Editor/Editor.tsx
+++ b/src/components/Editor/Editor.tsx
@@ -245,6 +245,8 @@ const Editor = ({ match }: RouteComponentProps<TParams>) => {
     switch (event.keyCode) {
       case 8:
         removeBar(actionId || '')
+        // Prevent navigation to previous page
+        event.preventDefault()
         break;
       case 37:
         // reduce time

--- a/src/components/Editor/Editor.tsx
+++ b/src/components/Editor/Editor.tsx
@@ -1177,7 +1177,7 @@ const Editor = ({ match }: RouteComponentProps<TParams>) => {
               <>
                 <button onClick={() => setShowCadenceInput(!showCadenceInput)} title='Cadence' style={{backgroundImage:`url(${CadenceIcon})`,backgroundPosition:'center',backgroundSize:'25px',backgroundRepeat:'no-repeat'}}><FontAwesomeIcon icon={faCopy} size="lg" fixedWidth color="rgba(0,0,0,0)" /></button>
                 {(showCadenceInput || cadence !== 0) &&
-                  <input className="textInput" type="number" min="40" max="150" name="cadence" value={cadence} onChange={(e) => saveCadence(actionId, parseInt(e.target.value))} />
+                  <input className="textInput" type="number" min="40" max="150" name="cadence" value={cadence} onChange={(e) => saveCadence(actionId, parseInt(e.target.value))} onKeyDown={(e) => { e.stopPropagation(); }} />
                 }
               </>
               :

--- a/src/components/Editor/Editor.tsx
+++ b/src/components/Editor/Editor.tsx
@@ -1298,14 +1298,14 @@ const Editor = ({ match }: RouteComponentProps<TParams>) => {
         {sportType === "bike" &&
           <div className="form-input">
             <label htmlFor="ftp">FTP (W)</label>
-            <input className="textInput" type="number" name="ftp" value={ftp} onChange={(e) => setFtp(parseInt(e.target.value))} />
+            <input className="textInput" type="number" name="ftp" value={ftp} onChange={(e) => setFtp(parseInt(e.target.value))} onKeyDown={(e) => { e.stopPropagation(); }} />
           </div>
         }
 
         {sportType === "bike" &&
           <div className="form-input">
             <label htmlFor="weight">Body Weight (Kg)</label>
-            <input className="textInput" type="number" name="weight" value={weight} onChange={(e) => setWeight(parseInt(e.target.value))} />
+            <input className="textInput" type="number" name="weight" value={weight} onChange={(e) => setWeight(parseInt(e.target.value))} onKeyDown={(e) => { e.stopPropagation(); }} />
           </div>
         }
 

--- a/src/components/Editor/Editor.tsx
+++ b/src/components/Editor/Editor.tsx
@@ -241,6 +241,10 @@ const Editor = ({ match }: RouteComponentProps<TParams>) => {
   }
 
   function handleKeyPress(event: React.KeyboardEvent<HTMLDivElement>) {
+    if (event.target instanceof HTMLInputElement) {
+      // Ignore key presses coming from input elements
+      return;
+    }
 
     switch (event.keyCode) {
       case 8:
@@ -1179,7 +1183,7 @@ const Editor = ({ match }: RouteComponentProps<TParams>) => {
               <>
                 <button onClick={() => setShowCadenceInput(!showCadenceInput)} title='Cadence' style={{backgroundImage:`url(${CadenceIcon})`,backgroundPosition:'center',backgroundSize:'25px',backgroundRepeat:'no-repeat'}}><FontAwesomeIcon icon={faCopy} size="lg" fixedWidth color="rgba(0,0,0,0)" /></button>
                 {(showCadenceInput || cadence !== 0) &&
-                  <input className="textInput" type="number" min="40" max="150" name="cadence" value={cadence} onChange={(e) => saveCadence(actionId, parseInt(e.target.value))} onKeyDown={(e) => { e.stopPropagation(); }} />
+                  <input className="textInput" type="number" min="40" max="150" name="cadence" value={cadence} onChange={(e) => saveCadence(actionId, parseInt(e.target.value))} />
                 }
               </>
               :
@@ -1300,14 +1304,14 @@ const Editor = ({ match }: RouteComponentProps<TParams>) => {
         {sportType === "bike" &&
           <div className="form-input">
             <label htmlFor="ftp">FTP (W)</label>
-            <input className="textInput" type="number" name="ftp" value={ftp} onChange={(e) => setFtp(parseInt(e.target.value))} onKeyDown={(e) => { e.stopPropagation(); }} />
+            <input className="textInput" type="number" name="ftp" value={ftp} onChange={(e) => setFtp(parseInt(e.target.value))} />
           </div>
         }
 
         {sportType === "bike" &&
           <div className="form-input">
             <label htmlFor="weight">Body Weight (Kg)</label>
-            <input className="textInput" type="number" name="weight" value={weight} onChange={(e) => setWeight(parseInt(e.target.value))} onKeyDown={(e) => { e.stopPropagation(); }} />
+            <input className="textInput" type="number" name="weight" value={weight} onChange={(e) => setWeight(parseInt(e.target.value))} />
           </div>
         }
 

--- a/src/components/Editor/Editor.tsx
+++ b/src/components/Editor/Editor.tsx
@@ -199,15 +199,6 @@ const Editor = ({ match }: RouteComponentProps<TParams>) => {
 
   }, [segmentsRef, bars, ftp, instructions, weight, name, description, author, tags, sportType, durationType, oneMileTime, fiveKmTime, tenKmTime, halfMarathonTime, marathonTime])
 
-  useEffect(() => {
-
-    document.addEventListener('keydown', handleKeyPress)
-
-    return () => {
-      document.removeEventListener('keydown', handleKeyPress)
-    };
-  })
-
   function generateId() {
     return Math.random().toString(36).substr(2, 16)
   }
@@ -249,7 +240,7 @@ const Editor = ({ match }: RouteComponentProps<TParams>) => {
     }
   }
 
-  function handleKeyPress(event: { keyCode: any }) {
+  function handleKeyPress(event: React.KeyboardEvent<HTMLDivElement>) {
 
     switch (event.keyCode) {
       case 8:
@@ -1026,7 +1017,8 @@ const Editor = ({ match }: RouteComponentProps<TParams>) => {
   }
 
   return (
-    <div className="container">
+    // Adding tabIndex allows div element to receive keyboard events
+    <div className="container" onKeyDown={handleKeyPress} tabIndex={0}>
       <Helmet>
         <title>{name ? `${name} - Zwift Workout Editor` : "My Workout - Zwift Workout Editor"}</title>
         <meta name="description" content={description} />


### PR DESCRIPTION
Fixes #15 

- Switch to purely React-based keyboard events handling
- Prevent propagation of key events from inputs
- Prevent navigation to previous page when backspace key is pressed.

Tested in Firefox / Chrome / Safari.

**Additional thoughts**

I think this `preventPropagation()` isn't really a good solution here as one needs to tack it on to all inputs, and it's easy to forget about it when adding new inputs to page. I'm not fully sure what would be a better way. Some ideas cross my mind:

- Move all inputs to some other div that isn't a child of the element on which these global key events are listened on (looks cumbersome).
- Check the target of the event inside `handleKeyPress` and do nothing in case the event originates from an input element.

**Edit**

After some further thought implemented the latter idea.
