### PR TITLE
Extract LeftRightToggle component and use stricter types

### DIFF
--- a/src/components/Editor/Editor.css
+++ b/src/components/Editor/Editor.css
@@ -268,17 +268,6 @@ label {
   max-width: 120px;  
   padding: 0 10px;
 }
-.switch {
-  display: flex;
-  flex-direction: row;
-  color: lightgray;
-}
-.switch > .icon {
-  padding: 5px;
-}
-.switch > .icon.active {
-  color: #00C46A;  
-}
 
 .run-workout {
   display: flex;  

--- a/src/components/Editor/Editor.tsx
+++ b/src/components/Editor/Editor.tsx
@@ -70,6 +70,9 @@ interface Message {
 
 type TParams = { id: string };
 
+export type SportType = "bike" | "run";
+export type DurationType = "time" | "distance";
+
 const Editor = ({ match }: RouteComponentProps<TParams>) => {
 
   const { v4: uuidv4 } = require('uuid');
@@ -105,10 +108,10 @@ const Editor = ({ match }: RouteComponentProps<TParams>) => {
   const [showWorkouts, setShowWorkouts] = useState(false)
 
   // bike or run
-  const [sportType, setSportType] = useState(localStorage.getItem('sportType') || 'bike')
+  const [sportType, setSportType] = useState<SportType>(localStorage.getItem('sportType') as SportType || 'bike')
 
   // distance or time
-  const [durationType, setDurationType] = useState(localStorage.getItem('durationType') || 'time')
+  const [durationType, setDurationType] = useState<DurationType>(localStorage.getItem('durationType') as DurationType || 'time')
 
   const [oneMileTime, setOneMileTime] = useState(localStorage.getItem('oneMileTime') || '')
   const [fiveKmTime, setFiveKmTime] = useState(localStorage.getItem('fiveKmTime') || '')
@@ -984,7 +987,7 @@ const Editor = ({ match }: RouteComponentProps<TParams>) => {
             <input className="textInput" value={helpers.getStressScore(bars, ftp)} disabled />
           </div>
           {sportType === 'run' &&
-            <LeftRightToggle
+            <LeftRightToggle<"time","distance">
               label="Duration Type"
               leftValue="time"
               rightValue="distance"
@@ -994,7 +997,7 @@ const Editor = ({ match }: RouteComponentProps<TParams>) => {
               onChange={setDurationType}
             />
           }
-          <LeftRightToggle
+          <LeftRightToggle<"bike","run">
             label="Sport Type"
             leftValue="bike"
             rightValue="run"

--- a/src/components/Editor/Editor.tsx
+++ b/src/components/Editor/Editor.tsx
@@ -28,7 +28,7 @@ import LoginForm from '../Forms/LoginForm'
 import { Helmet } from "react-helmet";
 import { RouteComponentProps } from 'react-router-dom';
 import ReactGA from 'react-ga';
-import Switch from "react-switch";
+import LeftRightToggle from './LeftRightToggle'
 import { stringType } from 'aws-sdk/clients/iam'
 import TimePicker from 'rc-time-picker'
 import 'rc-time-picker/assets/index.css'
@@ -984,24 +984,25 @@ const Editor = ({ match }: RouteComponentProps<TParams>) => {
             <input className="textInput" value={helpers.getStressScore(bars, ftp)} disabled />
           </div>
           {sportType === 'run' &&
-            <div className="form-input">
-              <label>Duration Type</label>
-              <div className="switch">
-                <FontAwesomeIcon className={`icon bike ${durationType === "time" ? "active" : ""}`} icon={faClock} size="lg" fixedWidth />
-                <Switch onChange={() => setDurationType(durationType === "time" ? "distance" : "time")} checked={durationType !== "time"} checkedIcon={false} uncheckedIcon={false} onColor="#00C46A" offColor="#00C46A" />
-                <FontAwesomeIcon className={`icon run ${durationType === "distance" ? "active" : ""}`} icon={faRuler} size="lg" fixedWidth />
-              </div>
-            </div>
+            <LeftRightToggle
+              label="Duration Type"
+              leftValue="time"
+              rightValue="distance"
+              leftIcon={faClock}
+              rightIcon={faRuler}
+              selected={durationType}
+              onChange={setDurationType}
+            />
           }
-          <div className="form-input">
-            <label>Sport Type</label>
-            <div className="switch">
-              <FontAwesomeIcon className={`icon bike ${sportType === "bike" ? "active" : ""}`} icon={faBiking} size="lg" fixedWidth />
-              <Switch onChange={switchSportType} checked={sportType !== "bike"} checkedIcon={false} uncheckedIcon={false} onColor="#00C46A" offColor="#00C46A" />
-              <FontAwesomeIcon className={`icon run ${sportType === "run" ? "active" : ""}`} icon={faRunning} size="lg" fixedWidth />
-            </div>
-          </div>
-          
+          <LeftRightToggle
+            label="Sport Type"
+            leftValue="bike"
+            rightValue="run"
+            leftIcon={faBiking}
+            rightIcon={faRunning}
+            selected={sportType}
+            onChange={switchSportType}
+          />
         </div>
       </div>
       {sportType === "run" &&

--- a/src/components/Editor/Editor.tsx
+++ b/src/components/Editor/Editor.tsx
@@ -895,14 +895,9 @@ const Editor = ({ match }: RouteComponentProps<TParams>) => {
     }
   }
 
-  function switchSportType() {
-    if (sportType === "bike") {
-      setSportType("run")
-      setDurationType("distance")
-    } else {
-      setSportType("bike")
-      setDurationType("time")
-    }
+  function switchSportType(newSportType: SportType) {
+    setSportType(newSportType);
+    setDurationType(newSportType === "bike" ? "time" : "distance");
   }
 
   return (

--- a/src/components/Editor/LeftRightToggle.css
+++ b/src/components/Editor/LeftRightToggle.css
@@ -1,0 +1,11 @@
+.left-right-toggle {
+  display: flex;
+  flex-direction: row;
+  color: lightgray;
+}
+.left-right-toggle > .icon {
+  padding: 5px;
+}
+.left-right-toggle > .icon.active {
+  color: #00C46A;  
+}

--- a/src/components/Editor/LeftRightToggle.tsx
+++ b/src/components/Editor/LeftRightToggle.tsx
@@ -2,6 +2,7 @@ import { IconProp } from "@fortawesome/fontawesome-svg-core";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import React from "react";
 import Switch from "react-switch";
+import "./LeftRightToggle.css";
 
 interface LeftRightToggleProps {
   label: string;
@@ -18,9 +19,9 @@ const COLOR = "#00C46A";
 const LeftRightToggle = ({ label, leftValue, rightValue, leftIcon, rightIcon, selected, onChange }: LeftRightToggleProps) => (
   <div className="form-input">
     <label>{label}</label>
-    <div className="switch">
+    <div className="left-right-toggle">
       <FontAwesomeIcon
-        className={`icon bike ${selected === leftValue ? "active" : ""}`}
+        className={`icon ${selected === leftValue ? "active" : ""}`}
         icon={leftIcon}
         size="lg"
         fixedWidth
@@ -34,7 +35,7 @@ const LeftRightToggle = ({ label, leftValue, rightValue, leftIcon, rightIcon, se
         offColor={COLOR}
       />
       <FontAwesomeIcon
-        className={`icon run ${selected === rightValue ? "active" : ""}`}
+        className={`icon ${selected === rightValue ? "active" : ""}`}
         icon={rightIcon}
         size="lg"
         fixedWidth

--- a/src/components/Editor/LeftRightToggle.tsx
+++ b/src/components/Editor/LeftRightToggle.tsx
@@ -1,0 +1,46 @@
+import { IconProp } from "@fortawesome/fontawesome-svg-core";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import React from "react";
+import Switch from "react-switch";
+
+interface LeftRightToggleProps {
+  label: string;
+  leftValue: string;
+  rightValue: string;
+  leftIcon: IconProp;
+  rightIcon: IconProp;
+  selected: string;
+  onChange: (selected: string) => void;
+}
+
+const COLOR = "#00C46A";
+
+const LeftRightToggle = ({ label, leftValue, rightValue, leftIcon, rightIcon, selected, onChange }: LeftRightToggleProps) => (
+  <div className="form-input">
+    <label>{label}</label>
+    <div className="switch">
+      <FontAwesomeIcon
+        className={`icon bike ${selected === leftValue ? "active" : ""}`}
+        icon={leftIcon}
+        size="lg"
+        fixedWidth
+      />
+      <Switch
+        onChange={() => onChange(selected === leftValue ? rightValue : leftValue)}
+        checked={selected === rightValue}
+        checkedIcon={false}
+        uncheckedIcon={false}
+        onColor={COLOR}
+        offColor={COLOR}
+      />
+      <FontAwesomeIcon
+        className={`icon run ${selected === rightValue ? "active" : ""}`}
+        icon={rightIcon}
+        size="lg"
+        fixedWidth
+      />
+    </div>
+  </div>
+);
+
+export default LeftRightToggle;

--- a/src/components/Editor/LeftRightToggle.tsx
+++ b/src/components/Editor/LeftRightToggle.tsx
@@ -4,19 +4,19 @@ import React from "react";
 import Switch from "react-switch";
 import "./LeftRightToggle.css";
 
-interface LeftRightToggleProps {
+interface LeftRightToggleProps<TLeft,TRight> {
   label: string;
-  leftValue: string;
-  rightValue: string;
+  leftValue: TLeft;
+  rightValue: TRight;
   leftIcon: IconProp;
   rightIcon: IconProp;
-  selected: string;
-  onChange: (selected: string) => void;
+  selected: TLeft | TRight;
+  onChange: (selected: TLeft | TRight) => void;
 }
 
 const COLOR = "#00C46A";
 
-const LeftRightToggle = ({ label, leftValue, rightValue, leftIcon, rightIcon, selected, onChange }: LeftRightToggleProps) => (
+const LeftRightToggle = <TLeft,TRight>({ label, leftValue, rightValue, leftIcon, rightIcon, selected, onChange }: LeftRightToggleProps<TLeft,TRight>) => (
   <div className="form-input">
     <label>{label}</label>
     <div className="left-right-toggle">

--- a/src/components/Editor/createWorkoutXml.ts
+++ b/src/components/Editor/createWorkoutXml.ts
@@ -1,12 +1,12 @@
 import Builder from 'xmlbuilder'
-import { Bar, Instruction } from './Editor'
+import { Bar, Instruction, SportType, DurationType } from './Editor'
 
 interface Workout {
   author: string;
   name: string;
   description: string;
-  sportType: string;
-  durationType: string;
+  sportType: SportType;
+  durationType: DurationType;
   tags: string[];
   bars: Array<Bar>;
   instructions: Array<Instruction>;


### PR DESCRIPTION
- Extracted LeftRightToggle component
- Deleted unused CSS classes `.bike` and `.run`
- Renamed `.switch` CSS class to `.left-right-toggle`
- Declared `SportType` and `DurationType` types and applied these to corresponding React state fields. So one can no more accidentally call `setSportType("blah")` - only `setSportType("bike")` or `setSportType("run")` would now be allowed.
- Added type-parameters for the new component to better integrate with these more restricted types