### PR TITLE
Fix cadence field size inside Label popup (in Firefox)

### DIFF
--- a/src/components/Label/Label.css
+++ b/src/components/Label/Label.css
@@ -21,6 +21,14 @@
   font-size: 14px;
 }
 
-.cadenceLabel {
+.cadence-row {
+  display: flex;
+}
+.cadence-row > .cadenceLabel {
   font-size: 14px;
+  flex: 1;
+}
+.cadence-row > .textField {
+  min-width: 1px;
+  flex: 1;
 }

--- a/src/components/Label/Label.tsx
+++ b/src/components/Label/Label.tsx
@@ -49,10 +49,10 @@ const Label = (props: { sportType: string, duration: string, distance?: number, 
           {(props.powerStart / props.ftp * 100).toFixed(0)}% to {(props.powerEnd / props.ftp * 100).toFixed(0)}% {paces[props.pace || 0]} pace
         </div>
       }      
-      <div>    
+      <div className="cadence-row">
         <label className="cadenceLabel">Cadence</label>
-        <input type="number" min="40" max="150" step="5" name="cadence" value={props.cadence || ''} onChange={(e) => {if (props.setCadence) props.setCadence(parseInt(e.target.value))}} onClick={(e)=> {e.stopPropagation()}} className="textField" />
-      </div>       
+        <input type="number" min="40" max="150" step="5" name="cadence" value={props.cadence || ''} onChange={(e) => {if (props.setCadence) props.setCadence(parseInt(e.target.value))}} onClick={(e)=> {e.stopPropagation()}} className="textField cadence" />
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
With Firefox I'm currently seeing the cadence input extending outside of the Label:

<img width="330" alt="fx-before" src="https://user-images.githubusercontent.com/118201/103217097-6d82c580-4920-11eb-91a4-4a75a037e938.png">

After this fix:

<img width="237" alt="fx-after" src="https://user-images.githubusercontent.com/118201/103217181-afac0700-4920-11eb-900b-3a3b7451f471.png">


Additionally in Chrome the input seems kinda small:

<img width="247" alt="chrome-before" src="https://user-images.githubusercontent.com/118201/103217207-c2bed700-4920-11eb-8e0d-3e96952855a5.png">

After this fix, it fills up all the available space:

<img width="228" alt="chrome-after" src="https://user-images.githubusercontent.com/118201/103217236-d23e2000-4920-11eb-8bfa-9ccc54a9fe5d.png">
