### PR TITLE
Fix Cooldown PowerLow/PowerHigh values being swapped

### DIFF
--- a/src/components/Editor/createWorkoutXml.ts
+++ b/src/components/Editor/createWorkoutXml.ts
@@ -78,11 +78,11 @@ export default function createWorkoutXml({
         // add cadence if not zero
         bar.cadence !== 0 && segment.att("Cadence", bar.cadence);
       } else {
-        // cooldown
+        // cooldown (power decreases from startPower to endPower)
         segment = Builder.create(ramp)
           .att("Duration", durationType === "time" ? bar.time : bar.length)
-          .att("PowerLow", bar.startPower) // these 2 values are inverted
-          .att("PowerHigh", bar.endPower) // looks like a bug on zwift editor
+          .att("PowerLow", bar.endPower)
+          .att("PowerHigh", bar.startPower)
           .att("pace", bar.pace);
         // add cadence if not zero
         bar.cadence !== 0 && segment.att("Cadence", bar.cadence);


### PR DESCRIPTION
The Cooldown element was incorrectly assigning PowerLow to the higher start power and PowerHigh to the lower end power. This fix ensures PowerLow always contains the lower value and PowerHigh the higher value.

Fixes #107